### PR TITLE
Add spread-to-add gesture for inserting items in ReorderableListView

### DIFF
--- a/lib/src/material/reorderable_list.dart
+++ b/lib/src/material/reorderable_list.dart
@@ -104,6 +104,10 @@ class ReorderableListView extends StatefulWidget {
     this.autoScrollerVelocityScalar,
     this.dragBoundaryProvider,
     this.mouseCursor,
+    this.spreadEnabled = false,
+    this.onSpreadInsert,
+    this.spreadPlaceholderBuilder,
+    this.spreadPlaceholderHeight = 92.0,
   }) : assert(
          (itemExtent == null && prototypeItem == null) ||
              (itemExtent == null && itemExtentBuilder == null) ||
@@ -175,6 +179,10 @@ class ReorderableListView extends StatefulWidget {
     this.autoScrollerVelocityScalar,
     this.dragBoundaryProvider,
     this.mouseCursor,
+    this.spreadEnabled = false,
+    this.onSpreadInsert,
+    this.spreadPlaceholderBuilder,
+    this.spreadPlaceholderHeight = 92.0,
   }) : assert(itemCount >= 0),
        assert(
          (itemExtent == null && prototypeItem == null) ||


### PR DESCRIPTION
Adds SpreadGestureDetector widget that detects two-finger spread (mobile) or trackpad pinch (macOS) gestures to insert new items between list items.

Key features:
- Platform-specific gesture detection (Pointer API for mobile, Scale for Mac)
- Insertion point calculation based on item midpoints
- Spread threshold detection with visual feedback callbacks
- Auto-scrolling support during spread gesture
- Configurable thresholds and maximum gap height
